### PR TITLE
Revamp UI and add about/legal pages

### DIFF
--- a/app.py
+++ b/app.py
@@ -94,6 +94,16 @@ def champion_page(champ_name):
     return render_template('champion.html', champ_name=champ_name, skins=champ_skins, user=user_email, champ_votes=champ_votes)
 
 
+@app.route('/about')
+def about():
+    return render_template('about.html')
+
+
+@app.route('/legal')
+def legal():
+    return render_template('legal.html')
+
+
 @app.route('/vote/<champ_name>/<skin_id>', methods=['POST'])
 def vote_skin(champ_name, skin_id):
     if 'email' not in session:

--- a/static/styles.css
+++ b/static/styles.css
@@ -1,416 +1,148 @@
-/* Fonts */
+:root {
+  --bg: #0d1117;
+  --panel: #111827;
+  --panel-muted: #0f172a;
+  --border: #1f2937;
+  --text: #e5e7eb;
+  --muted: #9ca3af;
+  --accent: #0ea5e9;
+  --accent-strong: #22d3ee;
+  --shadow: 0 18px 40px rgba(0,0,0,0.45);
+  --radius: 16px;
+  --font: 'BeaufortforLOL', 'Segoe UI', system-ui, -apple-system, sans-serif;
+}
+
 @font-face {
   font-family: 'BeaufortforLOL';
   src: url('/static/fonts/BeaufortforLOL-Regular.otf') format('opentype');
   font-weight: 400;
-  font-style: normal;
-  font-display: swap;
-}
-@font-face {
-  font-family: 'BeaufortforLOL';
-  src: url('/static/fonts/BeaufortforLOL-Light.otf') format('opentype');
-  font-weight: 300;
-  font-style: normal;
   font-display: swap;
 }
 @font-face {
   font-family: 'BeaufortforLOL';
   src: url('/static/fonts/BeaufortforLOL-Bold.otf') format('opentype');
   font-weight: 700;
-  font-style: normal;
-  font-display: swap;
-}
-@font-face {
-  font-family: 'BeaufortforLOL';
-  src: url('/static/fonts/BeaufortforLOL-BoldItalic.otf') format('opentype');
-  font-weight: 700;
-  font-style: italic;
-  font-display: swap;
-}
-@font-face {
-  font-family: 'BeaufortforLOL';
-  src: url('/static/fonts/BeaufortforLOL-Heavy.otf') format('opentype');
-  font-weight: 900;
-  font-style: normal;
   font-display: swap;
 }
 
-/* Body & Global */
+* { box-sizing: border-box; }
 body {
-  background: #121212;
-  color: #eee;
-  font-family: 'BeaufortforLOL', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-  padding: 20px;
   margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at 20% 20%, rgba(34,211,238,0.05), transparent 25%),
+              radial-gradient(circle at 80% 0%, rgba(14,165,233,0.08), transparent 30%),
+              var(--bg);
+  color: var(--text);
+  font-family: var(--font);
+  line-height: 1.6;
+  padding-bottom: 60px;
 }
 
-h1 {
-  text-align: center;
-  margin-bottom: 30px;
-  font-weight: 900;
-  letter-spacing: 2px;
-  user-select: none;
-  font-style: normal;
-}
+a { color: var(--accent-strong); text-decoration: none; }
+a:hover { color: white; }
 
-a {
-  color: #0af;
-  text-decoration: none;
-  transition: color 0.3s ease;
-  font-family: 'BeaufortforLOL', sans-serif;
-  font-weight: 700;
-}
+main { width: min(1200px, 94vw); margin: 32px auto 0; display: flex; flex-direction: column; gap: 28px; }
 
-a:hover {
-  color: #08c;
-  
-}
-
-/* Auth Links */
-#authLinks {
-  text-align: center;
-  margin-bottom: 30px;
-  font-size: 1rem;
-  font-weight: 400;
-}
-
-#authLinks a {
-  margin: 0 10px;
-  font-style: normal;
-  transition: color 0.3s ease, font-style 0.3s ease;
-}
-
-#authLinks a:hover {
-  font-style: italic;
-}
-
-/* Search Bar */
-#searchBar {
-  width: 100%;
-  max-width: 400px;
-  padding: 12px 15px;
-  font-size: 1rem;
-  margin: 0 auto 40px;
-  display: block;
-  border-radius: 8px;
-  border: 1.5px solid #333;
-  background: #2a2a2a;
-  color: #eee;
-  font-weight: 300;
-  transition: border-color 0.3s ease, background-color 0.3s ease;
-}
-
-#searchBar:focus {
-  outline: none;
-  border-color: #0af;
-  background: #222;
-  box-shadow: 0 0 8px #0afaa6aa;
-  font-weight: 400;
-}
-
-/* Containers */
-.champions-container,
-.skins-container {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  gap: 24px;
-}
-
-/* Cards */
-.champion-card,
-.skin-card {
-  width: 300px;
-  background: #1e1e1e;
-  border-radius: 10px;
-  box-shadow: 0 5px 15px rgba(0, 0, 0, 0.7);
-  overflow: hidden;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  cursor: pointer;
-  user-select: none;
-  font-weight: 400;
-  font-family: 'BeaufortforLOL', sans-serif;
-  transition: transform 0.25s ease, box-shadow 0.25s ease;
-}
-
-.champion-card:hover,
-.skin-card:hover {
-  transform: scale(1.05);
-  font-weight: 700;
-}
-
-/* Images */
-.champion-card img,
-.skin-card img {
-  width: 100%;
-  height: 170px;
-  object-fit: cover;
-  border-bottom: 1px solid #333;
-  display: block;
-  margin: 0;
-  border-radius: 0;
-  user-select: none;
-}
-
-/* Champion Card Title */
-.champion-card h2 {
-  margin: 15px 0 15px;
-  font-size: 1.25rem;
-  font-weight: 700;
-  text-align: center;
-  color: #eee;
-  user-select: none;
-  font-style: normal;
-}
-
-/* Skin Card Description */
-.skin-card p {
-  margin: 12px 0 8px;
-  font-weight: 300;
-  text-align: center;
-  pointer-events: none;
-}
-
-/* Vote Section */
-.vote-count {
-  color: #0af;
-  font-weight: 600;
-  text-align: center;
-  user-select: none;
-  font-size: 1.2rem;
-  letter-spacing: 1px;
-  font-family: 'BeaufortforLOL', sans-serif;
-}
-
-.vote-buttons {
-  display: flex;
-  justify-content: center;
-  gap: 16px;
-  margin-bottom: 16px;
-  pointer-events: auto;
-}
-
-.vote-btn {
-  background: transparent;
-  border: none;
-
-  color: #0af;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  user-select: none;
-  font-family: 'BeaufortforLOL', sans-serif;
-  font-size: 1.5rem;
-}
-
-#modal {
-  display: none;
-  position: fixed;
-  top: 0; left: 0; right: 0; bottom: 0;
-  background: rgba(0,0,0,0.8);
-  justify-content: center;
-  align-items: center;
-  z-index: 9999;
-}
-
-#modal.active {
-  display: flex;
-}
-
-#modal img {
-  max-width: 90%;
-  max-height: 90%;
-  border: 2px solid white;
-  border-radius: 8px;
-}
-
-.close-btn {
-  position: absolute;
-  top: 15px;
-  right: 25px;
-  font-size: 2rem;
-  color: white;
-  cursor: pointer;
-  user-select: none;
-}
-
-/* Header */
-header {
-  width: 100%;
-  background: #1e1e1e;
-  padding: 12px 20px;
-  box-shadow: 0 2px 5px rgba(0,0,0,0.7);
-  display: flex;
-  align-items: center;
+.site-header {
+  position: sticky; top: 0; z-index: 10;
+  display: flex; align-items: center; gap: 16px;
   justify-content: space-between;
-  gap: 15px;
-  user-select: none;
-  position: sticky;
-  top: 0;
-  z-index: 1000;
-  flex-wrap: wrap;
-   
+  padding: 14px 3vw;
+  background: rgba(13,17,23,0.9);
+  backdrop-filter: blur(10px);
+  border-bottom: 1px solid var(--border);
 }
+.brand a { display: flex; align-items: center; gap: 10px; color: var(--text); font-weight: 700; letter-spacing: 0.5px; }
+.brand__pill { background: var(--accent); color: #0b1020; padding: 2px 10px; border-radius: 999px; font-size: 12px; text-transform: uppercase; }
+.brand__name { font-size: 18px; }
 
-header h1 {
-  margin: 0;
-  font-weight: 900;
-  font-size: 1.5rem;
-  letter-spacing: 2px;
-  color: #eee;
-  flex-shrink: 0;
+.site-nav { display: flex; gap: 14px; align-items: center; }
+.site-nav a { color: var(--muted); font-weight: 600; }
+.site-nav a:hover { color: var(--text); }
+
+.auth { display: flex; gap: 10px; align-items: center; }
+.welcome { color: var(--muted); font-weight: 600; }
+
+.button { display: inline-flex; align-items: center; justify-content: center; gap: 6px; padding: 10px 16px; border-radius: 10px; font-weight: 700; border: 1px solid transparent; transition: all 0.2s ease; cursor: pointer; }
+.button.primary { background: linear-gradient(135deg, var(--accent), var(--accent-strong)); color: #0b1020; box-shadow: 0 10px 20px rgba(34,211,238,0.25); }
+.button.primary:hover { transform: translateY(-1px); box-shadow: 0 14px 24px rgba(34,211,238,0.35); }
+.button.ghost { background: transparent; border-color: var(--border); color: var(--text); }
+.button.ghost:hover { border-color: var(--accent); color: var(--accent-strong); }
+.button.full { width: 100%; }
+
+.flash-area { width: min(1200px, 94vw); margin: 10px auto 0; display: grid; gap: 10px; }
+.flash { background: #0b1220; border: 1px solid var(--border); padding: 12px 14px; border-radius: 10px; box-shadow: var(--shadow); }
+
+.hero { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 20px; padding: 28px; background: var(--panel); border: 1px solid var(--border); border-radius: var(--radius); box-shadow: var(--shadow); }
+.hero h1 { margin: 10px 0; font-size: clamp(28px, 4vw, 36px); }
+.hero .lede { color: var(--muted); margin-bottom: 16px; }
+.hero-card { background: linear-gradient(135deg, rgba(34,211,238,0.1), rgba(14,165,233,0.05)); border: 1px solid var(--border); border-radius: 14px; padding: 18px; display: grid; gap: 10px; }
+.stat { font-size: 28px; font-weight: 800; }
+.note { color: var(--muted); font-size: 14px; }
+.actions { display: flex; flex-wrap: wrap; gap: 10px; }
+
+.panel { background: var(--panel); border: 1px solid var(--border); border-radius: var(--radius); padding: 20px; box-shadow: var(--shadow); }
+.panel--muted { background: var(--panel-muted); }
+.panel__header { display: flex; align-items: center; justify-content: space-between; gap: 12px; flex-wrap: wrap; border-bottom: 1px solid var(--border); padding-bottom: 12px; margin-bottom: 16px; }
+.panel__cta { color: var(--muted); font-weight: 700; }
+
+.panel__split { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 16px; align-items: start; }
+
+.eyebrow { text-transform: uppercase; letter-spacing: 1px; font-size: 12px; color: var(--accent-strong); margin: 0; }
+.lede { margin: 0; color: var(--muted); }
+
+.champions { display: grid; gap: 12px; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); }
+.champion-card { background: #0f172a; border: 1px solid var(--border); border-radius: 12px; overflow: hidden; display: flex; flex-direction: column; box-shadow: var(--shadow); transition: transform 0.2s ease, border-color 0.2s ease; }
+.champion-card__image { height: 160px; background-size: cover; background-position: center; }
+.champion-card__body { padding: 12px 14px; display: flex; justify-content: space-between; align-items: center; }
+.champion-card__name { font-weight: 800; }
+.champion-card__meta { color: var(--muted); font-size: 14px; }
+.champion-card:hover { transform: translateY(-4px); border-color: var(--accent); }
+
+.search input { background: #0b1220; border: 1px solid var(--border); color: var(--text); padding: 10px 12px; border-radius: 12px; width: 240px; }
+.search input:focus { outline: 2px solid var(--accent); }
+
+.list-card { background: #0b1220; border: 1px solid var(--border); border-radius: 12px; padding: 12px; display: grid; gap: 8px; }
+.list-card__item { color: var(--text); font-weight: 600; }
+
+.page-header { background: var(--panel); border: 1px solid var(--border); border-radius: var(--radius); padding: 20px; box-shadow: var(--shadow); display: flex; justify-content: space-between; gap: 12px; align-items: flex-start; flex-wrap: wrap; }
+.breadcrumb { color: var(--muted); display: flex; gap: 8px; align-items: center; }
+
+.skins-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 14px; }
+.skin-card { background: #0b1220; border: 1px solid var(--border); border-radius: 12px; overflow: hidden; box-shadow: var(--shadow); display: flex; flex-direction: column; }
+.skin-card__image { height: 170px; background-size: cover; background-position: center; border: none; width: 100%; cursor: pointer; }
+.skin-card__image:hover { filter: brightness(1.05); }
+.skin-card__body { padding: 14px; display: flex; align-items: center; justify-content: space-between; gap: 10px; }
+.skin-card__title { margin: 4px 0 0; font-size: 18px; }
+.vote { display: flex; align-items: center; gap: 10px; }
+.vote__button { background: linear-gradient(135deg, rgba(34,211,238,0.15), rgba(14,165,233,0.05)); border: 1px solid var(--border); color: var(--accent-strong); border-radius: 50%; width: 42px; height: 42px; font-size: 18px; cursor: pointer; transition: all 0.2s ease; }
+.vote__button:hover:not([disabled]) { transform: translateY(-1px); border-color: var(--accent); }
+.vote__button:disabled { opacity: 0.6; cursor: not-allowed; }
+.vote__count { font-weight: 800; font-size: 20px; }
+
+.modal { position: fixed; inset: 0; display: none; align-items: center; justify-content: center; z-index: 20; }
+.modal.is-open { display: flex; }
+.modal__overlay { position: absolute; inset: 0; background: rgba(0,0,0,0.8); }
+.modal__content { position: relative; z-index: 2; padding: 12px; background: #0b1220; border: 1px solid var(--border); border-radius: 12px; }
+.modal__content img { max-width: 80vw; max-height: 80vh; display: block; border-radius: 10px; }
+.modal__close { position: absolute; top: 8px; right: 8px; background: #111827; color: var(--text); border: 1px solid var(--border); border-radius: 50%; width: 32px; height: 32px; font-size: 18px; cursor: pointer; }
+
+.auth-shell { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 16px; }
+.auth-card, .auth-aside { background: var(--panel); border: 1px solid var(--border); border-radius: var(--radius); padding: 18px; box-shadow: var(--shadow); }
+.auth-aside { background: #0b1220; }
+.form { display: grid; gap: 10px; margin-top: 10px; }
+.form input { background: #0b1220; border: 1px solid var(--border); border-radius: 10px; padding: 12px; color: var(--text); }
+.form input:focus { outline: 2px solid var(--accent); }
+label { font-weight: 700; }
+.muted { color: var(--muted); }
+
+.site-footer { width: 100%; padding: 18px 3vw; border-top: 1px solid var(--border); color: var(--muted); background: #0b1220; display: flex; justify-content: space-between; align-items: center; gap: 10px; flex-wrap: wrap; position: fixed; bottom: 0; left: 0; }
+.footer-links { display: flex; gap: 12px; }
+
+.legal ul { padding-left: 18px; color: var(--text); }
+
+@media (max-width: 720px) {
+  .site-header { flex-wrap: wrap; }
+  .site-footer { position: static; }
+  body { padding-bottom: 0; }
 }
-
-#searchBar {
-  flex-grow: 1;
-  max-width: 400px;
-  padding: 8px 12px;
-  font-size: 1rem;
-  border-radius: 8px;
-  border: 1.5px solid #333;
-  background: #2a2a2a;
-  color: #eee;
-  font-weight: 300;
-  transition: border-color 0.3s ease, background-color 0.3s ease;
-  user-select: text;
-  margin: 0 10px;
-}
-
-#searchBar:focus {
-  outline: none;
-  border-color: #0af;
-  background: #222;
-  box-shadow: 0 0 8px #0afaa6aa;
-  font-weight: 400;
-}
-
-nav#authLinks {
-  display: flex;
-  align-items: center;
-  font-size: 1rem;
-  font-weight: 400;
-  color: #eee;
-  white-space: nowrap;
-  line-height: 1;
-  padding: 0;
-  margin: 0;
-  vertical-align: middle;
-}
-
-nav#authLinks a {
-  color: #0af;
-  font-weight: 700;
-  text-decoration: none;
-  margin-left: 10px;
-}
-
-nav#authLinks a:hover {
-  color: #08c;
-}
-.welcome-container {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  line-height: 1; /* tight line height */
-}
-
-.welcome-container span,
-.welcome-container a {
-  display: inline-flex;
-  align-items: center;
-  line-height: 1;
-  vertical-align: middle;
-  font-size: 1rem; /* ensure same font size */
-}
-
-
-
-
-/* Footer */
-footer {
-  width: 100%;
-  background: #1e1e1e;
-  color: #777;
-  text-align: center;
-  padding: 12px 20px;
-  font-size: 0.9rem;
-  user-select: none;
-  margin-top: 40px;
-  box-shadow: inset 0 1px 0 rgba(255,255,255,0.1);
-}
-
-/* Skin Card */
-
-.skin-card {
-  display: flex;
-  align-items: center; /* vertical center all children */
-
-}
-
-.skin-image {
-  width: 80px;
-  height: 80px;
-  object-fit: cover;
-  border-radius: 5px;
-  flex-shrink: 0;
-}
-
-/* skin-info is now a flex row for vertical center */
-.skin-info {
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  align-items: center; /* center the title */
-  position: relative;
-
-}
-
-.vote-left {
-  position: absolute;
-  left: 10px;
-
-  display: flex;
-  align-items: center;
-  gap: 6px;
-}
-
-.vote-btn {
-  font-size: 1.5rem;
-  color: rgb(146, 146, 146); /* consistent red heart */
-  background: transparent;
-  border: none;
-  cursor: pointer;
-  user-select: none;
-
-}
-
-.vote-count {
-  font-size: 1.2rem;
-  font-weight: 700;
-  color: #0af;
-  user-select: none;
-}
-
-/* Center skin name with margin top to clear vote elements */
-.skin-name {
-  margin-top: 40px; /* space so title doesn't overlap votes */
-  text-align: center;
-  font-weight: 300;
-  pointer-events: none;
-}
-
-.left-group {
-  display: flex;
-  align-items: center;  /* vertical centering */
-  gap: 8px; /* space between heart and number */
-}
-
-
-.vote-btn:hover {
-    color:crimson
-}
-
-

--- a/templates/about.html
+++ b/templates/about.html
@@ -1,0 +1,41 @@
+{% extends 'base.html' %}
+{% block title %}About | League Skins Vote{% endblock %}
+{% block content %}
+<section class="page-header">
+  <div>
+    <p class="eyebrow">Behind the platform</p>
+    <h1>Built for fans who obsess over cosmetics.</h1>
+    <p class="lede">League Skins Vote gathers every champion splash, lets players rank skins, and keeps the results transparent with account-bound votes.</p>
+  </div>
+</section>
+
+<section class="panel">
+  <div class="panel__split">
+    <div>
+      <p class="eyebrow">Data sources</p>
+      <h3>Official artwork, updated automatically.</h3>
+      <p>Skin splashes and metadata are pulled with <strong>lol_splash_downloader</strong> so the catalog stays current with new releases. Each splash is displayed exactly as Riot ships it.</p>
+    </div>
+    <div class="list-card">
+      <div class="list-card__item">🎨 Latest champion splashes</div>
+      <div class="list-card__item">🧭 Skin names and IDs per champion</div>
+      <div class="list-card__item">🗳️ Vote totals stored server-side</div>
+    </div>
+  </div>
+</section>
+
+<section class="panel panel--muted">
+  <div class="panel__split">
+    <div>
+      <p class="eyebrow">Experience</p>
+      <h3>Smooth browsing, clear rankings.</h3>
+      <p>Every champion page sorts skins by community votes in real time. Search filters help you jump straight to your main, and modal previews let you enjoy full splash quality.</p>
+    </div>
+    <div class="list-card">
+      <div class="list-card__item">🔍 Fast champion search</div>
+      <div class="list-card__item">⚡ Instant vote feedback</div>
+      <div class="list-card__item">🖼️ Full-screen splash previews</div>
+    </div>
+  </div>
+</section>
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>{% block title %}League Skins Vote{% endblock %}</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}" />
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+</head>
+<body>
+  <header class="site-header">
+    <div class="brand">
+      <a href="{{ url_for('index') }}" aria-label="League Skins Vote home">
+        <span class="brand__pill">Beta</span>
+        <span class="brand__name">League Skins Vote</span>
+      </a>
+    </div>
+    <nav class="site-nav">
+      <a href="{{ url_for('index') }}">Champions</a>
+      <a href="{{ url_for('about') }}">About</a>
+      <a href="{{ url_for('legal') }}">Legal</a>
+    </nav>
+    <div class="auth">
+      {% if session.email %}
+        <div class="welcome">Hi, {{ session.email.split('@')[0] }}</div>
+        <a class="button ghost" href="{{ url_for('logout') }}">Logout</a>
+      {% else %}
+        <a class="button ghost" href="{{ url_for('login') }}">Log in</a>
+        <a class="button primary" href="{{ url_for('register') }}">Create account</a>
+      {% endif %}
+    </div>
+  </header>
+
+  {% with messages = get_flashed_messages() %}
+    {% if messages %}
+      <div class="flash-area" role="status" aria-live="polite">
+        {% for message in messages %}
+          <div class="flash">{{ message }}</div>
+        {% endfor %}
+      </div>
+    {% endif %}
+  {% endwith %}
+
+  <main>
+    {% block content %}{% endblock %}
+  </main>
+
+  <footer class="site-footer">
+    <div>
+      Built for League fans. Artwork and champion data are property of Riot Games.
+    </div>
+    <div class="footer-links">
+      <a href="{{ url_for('legal') }}">Terms & Privacy</a>
+      <a href="{{ url_for('about') }}">How it works</a>
+    </div>
+  </footer>
+</body>
+</html>

--- a/templates/champion.html
+++ b/templates/champion.html
@@ -1,141 +1,124 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>{{ champ_name }} Skins - League Splash Arts</title>
-  <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}" />
-</head>
-<body>
+{% extends 'base.html' %}
+{% block title %}{{ champ_name }} skins | League Skins Vote{% endblock %}
+{% block content %}
+<section class="page-header">
+  <div>
+    <p class="eyebrow">{{ champ_name }}</p>
+    <h1>Rank every skin by community vote.</h1>
+    <p class="lede">Click a splash to view it in detail. Sign in to cast a single vote per skin and watch rankings reorder instantly.</p>
+  </div>
+  <div class="breadcrumb">
+    <a href="{{ url_for('index') }}">Champions</a>
+    <span aria-hidden="true">/</span>
+    <span>{{ champ_name }}</span>
+  </div>
+</section>
 
-  <header id="header-bar">
-    <h1>League Skins Vote</h1>
-    <nav id="authLinks">
-      <a href="{{ url_for('index') }}">← Back to all champions</a>
-      {% if session.email %}
-        <div class="welcome-container">
-          <span>Welcome, {{ session.email.split('@')[0] }}!</span>
-          <a href="{{ url_for('logout') }}">Logout</a>
-        </div>
-      {% else %}
-        <a href="{{ url_for('login') }}">Login</a> | <a href="{{ url_for('register') }}">Register</a>
-      {% endif %}
-    </nav>
-  </header>
-
-  <main>
-    <h1>{{ champ_name }} Skins</h1>
-
-    <div class="skins-container" id="skins-container">
-      {% for skin in skins %}
-        <div class="skin-card" data-skin-id="{{ skin.skin_num }}" data-champ-name="{{ champ_name }}">
-          <img src="{{ url_for('static', filename=skin.file_path) }}" alt="{{ skin.skin_name }}" class="skin-image" />
-          <div class="skin-info">
-            <div class="vote-left">
-              <button class="vote-btn" aria-label="Vote up"
-  {% if champ_votes[skin.skin_num].voted %} disabled style="color:crimson; opacity:1; cursor: not-allowed;" {% endif %}>
-  ❤︎
-</button>
-
-              <div class="vote-count" id="vote-count-{{ skin.skin_num }}">
-                {{ champ_votes[skin.skin_num].count if champ_votes and skin.skin_num in champ_votes else 0 }}
-              </div>
-            </div>
-            <p class="skin-name">{{ skin.skin_name }}</p>
-          </div>
-        </div>
-      {% endfor %}
+<section class="panel">
+  <div class="panel__header">
+    <div>
+      <p class="eyebrow">Skins</p>
+      <h2>{{ skins|length }} available skins</h2>
     </div>
-  </main>
-
-  <div id="modal" aria-hidden="true">
-    <span class="close-btn" role="button" aria-label="Close modal">&times;</span>
-    <img src="" alt="Skin Preview" id="modal-img" />
+    {% if not session.email %}
+      <div class="panel__cta">Login or create an account to vote.</div>
+    {% endif %}
   </div>
 
-  <footer id="footer-bar">
-    <p>Coded between queues. Fueled by losses. Made by Akrot.</p>
-  </footer>
+  <div class="skins-grid" id="skins-container">
+    {% for skin in skins %}
+      {% set vote_data = champ_votes.get(skin.skin_num, {'count': 0, 'voted': False}) %}
+      <article class="skin-card" data-skin-id="{{ skin.skin_num }}" data-champ-name="{{ champ_name }}">
+        <button class="skin-card__image" style="background-image:url('{{ url_for('static', filename=skin.file_path) }}');" aria-label="View {{ skin.skin_name }} splash" data-modal-src="{{ url_for('static', filename=skin.file_path) }}"></button>
+        <div class="skin-card__body">
+          <div>
+            <p class="eyebrow">{{ champ_name }}</p>
+            <h3 class="skin-card__title">{{ skin.skin_name }}</h3>
+          </div>
+          <div class="vote">
+            <button class="vote__button" {% if vote_data.voted %}disabled{% endif %}>
+              ❤
+            </button>
+            <div class="vote__count" id="vote-count-{{ skin.skin_num }}">{{ vote_data.count }}</div>
+          </div>
+        </div>
+      </article>
+    {% endfor %}
+  </div>
+</section>
 
-  <script>
-    const skinsContainer = document.getElementById('skins-container');
-    const modal = document.getElementById('modal');
-    const modalImg = document.getElementById('modal-img');
-    const closeBtn = modal.querySelector('.close-btn');
+<div id="modal" aria-hidden="true" class="modal">
+  <div class="modal__overlay"></div>
+  <div class="modal__content">
+    <button class="modal__close" aria-label="Close preview">×</button>
+    <img src="" alt="Skin preview" id="modal-img" />
+  </div>
+</div>
 
-    function sortSkins() {
-      const cards = Array.from(skinsContainer.children);
-      cards.sort((a, b) => {
-        const votesA = parseInt(a.querySelector('.vote-count').textContent) || 0;
-        const votesB = parseInt(b.querySelector('.vote-count').textContent) || 0;
-        return votesB - votesA;
-      });
-      cards.forEach(card => skinsContainer.appendChild(card));
-    }
+<script>
+  const skinsContainer = document.getElementById('skins-container');
+  const modal = document.getElementById('modal');
+  const modalImg = document.getElementById('modal-img');
+  const closeModalBtn = modal.querySelector('.modal__close');
 
-    document.querySelectorAll('.vote-btn').forEach(btn => {
-      btn.addEventListener('click', async e => {
-        e.stopPropagation();
-        const skinCard = e.target.closest('.skin-card');
-        if (!skinCard) return;
+  function sortSkins() {
+    const cards = Array.from(skinsContainer.children);
+    cards.sort((a, b) => {
+      const votesA = parseInt(a.querySelector('.vote__count').textContent) || 0;
+      const votesB = parseInt(b.querySelector('.vote__count').textContent) || 0;
+      return votesB - votesA;
+    });
+    cards.forEach(card => skinsContainer.appendChild(card));
+  }
 
-        const skinId = skinCard.dataset.skinId;
-        const champName = skinCard.dataset.champName;
-        if (!skinId || !champName) return alert('Invalid skin or champion.');
+  skinsContainer.querySelectorAll('.vote__button').forEach(btn => {
+    btn.addEventListener('click', async (e) => {
+      const card = e.target.closest('.skin-card');
+      const skinId = card.dataset.skinId;
+      const champName = card.dataset.champName;
 
-        try {
-          const response = await fetch(`/vote/${encodeURIComponent(champName)}/${encodeURIComponent(skinId)}`, {
-  method: 'POST',
-  headers: {
-    'Content-Type': 'application/json',
-  },
-});
+      try {
+        const response = await fetch(`/vote/${encodeURIComponent(champName)}/${encodeURIComponent(skinId)}`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' }
+        });
 
-if (response.ok) {
-  const data = await response.json();
-  const voteCountElem = skinCard.querySelector('.vote-count');
-  voteCountElem.textContent = data.votes;
-
-  // Disable button after vote
-  e.target.disabled = true;
-  e.target.style.opacity = '0.5';
-  e.target.style.cursor = 'not-allowed';
-} else {
-  const errorData = await response.json();
-  alert(errorData.error || 'Failed to vote.');
-}
-sortSkins();
-
-        } catch (error) {
-          console.error('Voting error:', error);
-          alert('An error occurred while voting.');
+        if (response.ok) {
+          const data = await response.json();
+          const countEl = card.querySelector('.vote__count');
+          countEl.textContent = data.votes;
+          btn.disabled = true;
+          sortSkins();
+        } else {
+          const error = await response.json();
+          alert(error.error || 'Unable to register vote.');
         }
-      });
+      } catch (err) {
+        alert('Network error while voting.');
+      }
     });
+  });
 
-    document.querySelectorAll('.skin-image').forEach(img => {
-      img.addEventListener('click', e => {
-        modalImg.src = e.target.src;
-        modalImg.alt = e.target.alt;
-        modal.classList.add('active');
-        modal.setAttribute('aria-hidden', 'false');
-      });
+  document.querySelectorAll('.skin-card__image').forEach(trigger => {
+    trigger.addEventListener('click', () => {
+      modalImg.src = trigger.dataset.modalSrc;
+      modal.classList.add('is-open');
+      modal.setAttribute('aria-hidden', 'false');
     });
+  });
 
-    function closeModal() {
-      modal.classList.remove('active');
-      modalImg.src = '';
-      modalImg.alt = '';
-      modal.setAttribute('aria-hidden', 'true');
-    }
+  function closeModal() {
+    modal.classList.remove('is-open');
+    modalImg.src = '';
+    modal.setAttribute('aria-hidden', 'true');
+  }
 
-    closeBtn.addEventListener('click', closeModal);
-    modal.addEventListener('click', e => {
-      if (e.target === modal) closeModal();
-    });
+  closeModalBtn.addEventListener('click', closeModal);
+  modal.querySelector('.modal__overlay').addEventListener('click', closeModal);
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape') closeModal();
+  });
 
-    sortSkins();
-  </script>
-
-</body>
-</html>
+  sortSkins();
+</script>
+{% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,56 +1,72 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <title>League Skins Vote</title>
-  <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
-</head>
-<body>
+{% extends 'base.html' %}
+{% block title %}League Skins Vote{% endblock %}
+{% block content %}
+<section class="hero">
+  <div>
+    <p class="eyebrow">Community-crafted</p>
+    <h1>Vote the definitive best skin for every champion.</h1>
+    <p class="lede">Browse every splash, compare cosmetics, and champion the looks you love. Votes are transparent and locked to your account for fair results.</p>
+    <div class="actions">
+      <a class="button primary" href="#champion-grid">Browse champions</a>
+      <a class="button ghost" href="{{ url_for('about') }}">See how it works</a>
+    </div>
+  </div>
+  <div class="hero-card">
+    <div class="stat">{{ all_champions|length }} Champions</div>
+    <div class="stat">{{ votes|length }} Skins voted</div>
+    <p class="note">Skins and art pulled via lol_splash_downloader.</p>
+  </div>
+</section>
 
-<header id="header-bar">
-  <h1>League Skins Vote</h1>
-  <input type="text" id="searchBar" placeholder="Search champions..." />
-  <nav id="authLinks">
-    {% if session.email %}
-      <div class="welcome-container">
-        <span>Welcome, {{ session.email.split('@')[0] }}!</span>
-        <a href="{{ url_for('logout') }}">Logout</a>
-      </div>
-    {% else %}
-      <a href="{{ url_for('login') }}">Login</a> | <a href="{{ url_for('register') }}">Register</a>
-    {% endif %}
-  </nav>
-</header>
-
-<main>
-    <h1>Vote for your favorite skins!</h1>
-  <div class="champions-container">
+<section class="panel">
+  <div class="panel__header">
+    <div>
+      <p class="eyebrow">All champions</p>
+      <h2>Choose a champion to start voting.</h2>
+    </div>
+    <div class="search">
+      <input type="search" id="searchBar" placeholder="Search champions" aria-label="Search champions" />
+    </div>
+  </div>
+  <div class="champions" id="champion-grid">
     {% for champ, skins in all_champions.items() %}
-      <div class="champion-card">
-        <a href="{{ url_for('champion_page', champ_name=champ) }}">
-          <img src="{{ url_for('static', filename=skins[0].file_path) }}" alt="{{ champ }} splash" />
-          <h2>{{ champ }}</h2>
-        </a>
-      </div>
+      <a class="champion-card" href="{{ url_for('champion_page', champ_name=champ) }}" data-name="{{ champ | lower }}">
+        <div class="champion-card__image" style="background-image:url('{{ url_for('static', filename=skins[0].file_path) }}');"></div>
+        <div class="champion-card__body">
+          <div class="champion-card__name">{{ champ }}</div>
+          <div class="champion-card__meta">{{ skins|length }} skins</div>
+        </div>
+      </a>
     {% endfor %}
   </div>
-</main>
+</section>
 
-<footer id="footer-bar">
-  <p>Coded between queues. Fueled by losses. Made by Akrot.</p>
-</footer>
+<section class="panel panel--muted">
+  <div class="panel__split">
+    <div>
+      <p class="eyebrow">Fair by design</p>
+      <h3>One account, one vote per skin.</h3>
+      <p>Votes are tied to verified accounts to keep results trustworthy. Explore splash art, rank favorites, and see community trends update instantly.</p>
+    </div>
+    <div class="list-card">
+      <div class="list-card__item">📩 Quick sign-up and email verification</div>
+      <div class="list-card__item">🛡️ Anti-duplicate vote safeguards</div>
+      <div class="list-card__item">📊 Votes stored server-side for accuracy</div>
+      <div class="list-card__item">🎨 Official splash art sourced automatically</div>
+    </div>
+  </div>
+</section>
 
 <script>
-  const searchBar = document.getElementById('searchBar');
-  const champions = document.querySelectorAll('.champion-card');
+  const searchInput = document.getElementById('searchBar');
+  const championCards = document.querySelectorAll('.champion-card');
 
-  searchBar.addEventListener('input', () => {
-    const query = searchBar.value.toLowerCase();
-    champions.forEach(card => {
-      const name = card.querySelector('h2').textContent.toLowerCase();
+  searchInput.addEventListener('input', () => {
+    const query = searchInput.value.toLowerCase();
+    championCards.forEach(card => {
+      const name = card.dataset.name;
       card.style.display = name.includes(query) ? 'flex' : 'none';
     });
   });
 </script>
-
-</body>
-</html>
+{% endblock %}

--- a/templates/legal.html
+++ b/templates/legal.html
@@ -1,0 +1,51 @@
+{% extends 'base.html' %}
+{% block title %}Legal | League Skins Vote{% endblock %}
+{% block content %}
+<section class="page-header">
+  <div>
+    <p class="eyebrow">Stay informed</p>
+    <h1>Terms of use & privacy.</h1>
+    <p class="lede">We built this fan project with respect for Riot's policies and your data. Here's how we handle both.</p>
+  </div>
+</section>
+
+<section class="panel">
+  <div class="panel__split legal">
+    <div>
+      <p class="eyebrow">Terms of use</p>
+      <h3>Community-first voting.</h3>
+      <ul>
+        <li>Accounts are required to vote; one vote per skin per account.</li>
+        <li>Do not attempt to bypass vote limits or interfere with service availability.</li>
+        <li>All League of Legends assets remain the property of Riot Games; this site is a fan project.</li>
+        <li>Content is provided as-is without warranty; availability may change at any time.</li>
+      </ul>
+    </div>
+    <div>
+      <p class="eyebrow">Privacy</p>
+      <h3>Minimal data, kept locally.</h3>
+      <ul>
+        <li>Email and hashed passwords are stored to enable authentication.</li>
+        <li>Votes are tied to your account email to ensure one-vote-per-skin integrity.</li>
+        <li>No behavioral tracking, advertising, or third-party analytics are used.</li>
+        <li>Contact support to remove your account data at any time.</li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<section class="panel panel--muted">
+  <div class="panel__split">
+    <div>
+      <p class="eyebrow">Attribution</p>
+      <h3>Riot Games ownership</h3>
+      <p>League of Legends, and all associated assets, are trademarks or registered trademarks of Riot Games, Inc. All splashes are used under their fan content policy. This project is unaffiliated with Riot and exists for community enjoyment.</p>
+    </div>
+    <div class="list-card">
+      <div class="list-card__item">Respect Riot's brand guidelines</div>
+      <div class="list-card__item">No monetization or ads</div>
+      <div class="list-card__item">Built for research and fun</div>
+    </div>
+  </div>
+</section>
+{% endblock %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,81 +1,26 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <title>Login - League Splash Arts</title>
-  <style>
-    body {
-      background: #121212;
-      color: #eee;
-      font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      height: 100vh;
-      margin: 0;
-    }
-    form {
-      background: #1e1e1e;
-      padding: 30px 40px;
-      border-radius: 12px;
-      box-shadow: 0 0 15px rgba(0,0,0,0.7);
-      width: 320px;
-      display: flex;
-      flex-direction: column;
-    }
-    h2 {
-      text-align: center;
-      margin-bottom: 25px;
-    }
-    input {
-      margin-bottom: 20px;
-      padding: 12px 15px;
-      border-radius: 6px;
-      border: none;
-      font-size: 1rem;
-      background: #2a2a2a;
-      color: #eee;
-    }
-    input:focus {
-      outline: 2px solid #0af;
-      background: #222;
-    }
-    button {
-      padding: 12px;
-      border: none;
-      border-radius: 6px;
-      background: #0af;
-      color: white;
-      font-weight: 700;
-      cursor: pointer;
-      transition: background 0.3s ease;
-    }
-    button:hover {
-      background: #08c;
-    }
-    .message {
-      text-align: center;
-      margin-top: 15px;
-      color: #f55;
-      font-size: 0.9rem;
-    }
-  </style>
-</head>
-<body>
-  <form method="POST" action="{{ url_for('login') }}">
-    <h2>Login</h2>
-    <input type="email" name="email" placeholder="Email" required autofocus />
-    <input type="password" name="password" placeholder="Password" required />
-    <button type="submit">Log In</button>
-
-    {% with messages = get_flashed_messages() %}
-      {% if messages %}
-        <div class="message">
-          {% for message in messages %}
-            <p>{{ message }}</p>
-          {% endfor %}
-        </div>
-      {% endif %}
-    {% endwith %}
-  </form>
-</body>
-</html>
+{% extends 'base.html' %}
+{% block title %}Login | League Skins Vote{% endblock %}
+{% block content %}
+<section class="auth-shell">
+  <div class="auth-card">
+    <p class="eyebrow">Welcome back</p>
+    <h1>Sign in to vote.</h1>
+    <form method="POST" action="{{ url_for('login') }}" class="form">
+      <label>Email</label>
+      <input type="email" name="email" placeholder="you@example.com" required />
+      <label>Password</label>
+      <input type="password" name="password" placeholder="••••••••" required />
+      <button type="submit" class="button primary full">Log in</button>
+    </form>
+    <p class="muted">No account yet? <a href="{{ url_for('register') }}">Create one</a>.</p>
+  </div>
+  <div class="auth-aside">
+    <h3>Account perks</h3>
+    <ul>
+      <li>One verified vote per skin</li>
+      <li>Instant tally updates</li>
+      <li>Saved history per champion</li>
+    </ul>
+  </div>
+</section>
+{% endblock %}

--- a/templates/register.html
+++ b/templates/register.html
@@ -1,106 +1,28 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <title>Register - League Splash Arts</title>
-  <style>
-    body {
-      background: #121212;
-      color: #eee;
-      font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      height: 100vh;
-      margin: 0;
-    }
-    form {
-      background: #222;
-      padding: 30px;
-      border-radius: 10px;
-      width: 320px;
-      box-shadow: 0 5px 20px rgba(0,0,0,0.8);
-    }
-    h2 {
-      margin-bottom: 20px;
-      font-weight: 700;
-      text-align: center;
-      letter-spacing: 1.5px;
-    }
-    label {
-      display: block;
-      margin-bottom: 8px;
-      font-weight: 600;
-    }
-    input[type="email"],
-    input[type="password"] {
-      width: 100%;
-      padding: 10px;
-      margin-bottom: 15px;
-      border-radius: 5px;
-      border: none;
-      background: #333;
-      color: #eee;
-      font-size: 1rem;
-    }
-    input[type="email"]:focus,
-    input[type="password"]:focus {
-      outline: none;
-      background: #444;
-      border: 1px solid #0af;
-    }
-    button {
-      width: 100%;
-      padding: 12px;
-      background: #0af;
-      border: none;
-      border-radius: 5px;
-      color: #121212;
-      font-weight: 700;
-      font-size: 1.1rem;
-      cursor: pointer;
-      transition: background 0.3s ease;
-    }
-    button:hover {
-      background: #08c;
-    }
-    .message {
-      margin-top: 15px;
-      text-align: center;
-      color: #f66;
-      font-weight: 600;
-    }
-    a {
-      display: block;
-      margin-top: 15px;
-      text-align: center;
-      color: #0af;
-      text-decoration: none;
-    }
-    a:hover {
-      text-decoration: underline;
-    }
-  </style>
-</head>
-<body>
-  <form method="POST" action="{{ url_for('register') }}">
-    <h2>Create Account</h2>
-
-    <label for="email">Email</label>
-    <input type="email" name="email" id="email" placeholder="your@email.com" required />
-
-    <label for="password">Password</label>
-    <input type="password" name="password" id="password" placeholder="Strong password" required />
-
-    <label for="password_confirm">Confirm Password</label>
-    <input type="password" name="password_confirm" id="password_confirm" placeholder="Re-enter password" required />
-
-    <button type="submit">Register</button>
-
-    {% if message %}
-      <div class="message">{{ message }}</div>
-    {% endif %}
-
-    <a href="{{ url_for('login') }}">Already have an account? Login</a>
-  </form>
-</body>
-</html>
+{% extends 'base.html' %}
+{% block title %}Create account | League Skins Vote{% endblock %}
+{% block content %}
+<section class="auth-shell">
+  <div class="auth-card">
+    <p class="eyebrow">Join the community</p>
+    <h1>Create an account.</h1>
+    <form method="POST" action="{{ url_for('register') }}" class="form">
+      <label>Email</label>
+      <input type="email" name="email" placeholder="you@example.com" required />
+      <label>Password</label>
+      <input type="password" name="password" placeholder="At least 8 characters" required />
+      <label>Confirm password</label>
+      <input type="password" name="password_confirm" placeholder="Re-enter password" required />
+      <button type="submit" class="button primary full">Create account</button>
+    </form>
+    <p class="muted">Already have an account? <a href="{{ url_for('login') }}">Log in</a>.</p>
+  </div>
+  <div class="auth-aside">
+    <h3>Why sign up?</h3>
+    <ul>
+      <li>Keep votes fair with one-per-skin rules</li>
+      <li>See rankings reorder as soon as you vote</li>
+      <li>Track every champion's best looks</li>
+    </ul>
+  </div>
+</section>
+{% endblock %}


### PR DESCRIPTION
## Summary
- rebuild the layout with a shared base template, refreshed hero, champion grid, and skin voting experience
- align login/registration with the new visual system and add descriptive about and legal pages
- modernize styling with Riot-inspired palette, modal previews, and usability improvements

## Testing
- python -m compileall app.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a040ec36c832b912a3352d3c29860)