### PR TITLE
Keep footer fixed and streamline onboarding

### DIFF
--- a/app.py
+++ b/app.py
@@ -14,7 +14,7 @@ app = Flask(__name__)
 app.secret_key = os.environ.get('FLASK_SECRET_KEY', 'your_secret_key_here')
 
 ADMIN_EMAIL = os.environ.get('ADMIN_EMAIL', 'abdallhhelles97@gmail.com').lower()
-ADMIN_PASSWORD = os.environ.get('ADMIN_PASSWORD', 'abdallhhelles..')
+ADMIN_PASSWORD = os.environ.get('ADMIN_PASSWORD', 'abdallhhelles')
 FEEDBACK_DB_FILE = 'feedback_db.json'
 
 USERS_DB_FILE = 'users_db.json'
@@ -137,7 +137,7 @@ def ensure_admin_user():
             'password': hashed_admin_password,
             'verified': True,
             'token': '',
-            'username': 'Admin',
+            'username': 'admin',
             'main_champion': '',
             'favorite_champion': '',
             'favorites': [],
@@ -151,7 +151,7 @@ def ensure_admin_user():
         admin_profile['password'] = hashed_admin_password
         admin_profile['verified'] = True
         admin_profile['token'] = ''
-        admin_profile.setdefault('username', 'Admin')
+        admin_profile['username'] = 'admin'
         admin_profile.setdefault('main_champion', '')
         admin_profile.setdefault('favorite_champion', '')
         admin_profile.setdefault('favorites', [])
@@ -787,8 +787,6 @@ def contact():
             return redirect(url_for('contact'))
 
         profile = users.get(user_email, {}) if user_email else {}
-        server = (request.form.get('server') or profile.get('server') or '').strip()
-        main_role = (request.form.get('main_role') or profile.get('main_role') or '').strip()
         entry = {
             'id': str(uuid.uuid4()),
             'topic': subject,
@@ -798,9 +796,6 @@ def contact():
             'created_at': uuid.uuid1().hex,
             'type': 'contact',
             'category': category,
-            'server': server,
-            'main_role': main_role,
-            'favorite_champion': profile.get('favorite_champion', ''),
             'contact_email': contact_email or user_email,
         }
         feedback_entries.append(entry)
@@ -821,9 +816,6 @@ def register():
         username = (request.form.get('username') or '').strip()
         password = request.form['password']
         password_confirm = request.form.get('password_confirm')
-        server = (request.form.get('server') or '').strip()
-        main_role = (request.form.get('main_role') or '').strip()
-        favorite_champion = (request.form.get('favorite_champion') or '').strip()
 
         if not email or not password or not password_confirm or not username:
             flash('Please fill all fields.')
@@ -851,11 +843,11 @@ def register():
             'token': verification_token,
             'username': username,
             'main_champion': '',
-            'favorite_champion': favorite_champion,
+            'favorite_champion': '',
             'favorites': [],
             'reset_token': '',
-            'server': server,
-            'main_role': main_role,
+            'server': '',
+            'main_role': '',
         }
         save_users(users)
 

--- a/static/styles.css
+++ b/static/styles.css
@@ -47,7 +47,7 @@ body {
   color: var(--text);
   font-family: var(--font);
   line-height: 1.6;
-  padding-bottom: 80px;
+  padding-bottom: 160px;
 }
 
 a { color: var(--accent-strong); text-decoration: none; }
@@ -166,15 +166,13 @@ main { width: min(1200px, 94vw); margin: 32px auto 0; display: flex; flex-direct
 label { font-weight: 700; }
 .muted { color: var(--muted); }
 
-.site-footer { width: 100%; padding: 18px 3vw; border-top: 1px solid var(--border); color: var(--muted); background: var(--panel); display: flex; justify-content: space-between; align-items: center; gap: 10px; flex-wrap: wrap; position: static; left: 0; transition: transform 0.2s ease; box-shadow: var(--shadow); }
-.site-footer[data-pinned="true"] { position: fixed; bottom: 0; }
-.site-footer[data-collapsed="true"] { transform: translateY(140%); }
+.site-footer { width: 100%; padding: 18px 3vw; border-top: 1px solid var(--border); color: var(--muted); background: var(--panel); display: flex; justify-content: space-between; align-items: center; gap: 10px; flex-wrap: wrap; position: fixed; left: 0; bottom: 0; box-shadow: var(--shadow); z-index: 10; }
 .footer-links { display: flex; gap: 12px; flex-wrap: wrap; }
-.footer-controls { display: flex; gap: 8px; align-items: center; }
 .footer-main { display: flex; flex-direction: column; gap: 8px; }
 .floating { position: fixed; bottom: 16px; right: 16px; box-shadow: var(--shadow); }
 .bmc { margin-left: 10px; font-weight: 700; }
-.cookie-bar { position: fixed; bottom: 12px; left: 50%; transform: translateX(-50%); background: var(--panel); border: 1px solid var(--border); border-radius: 12px; padding: 14px; box-shadow: var(--shadow); display: flex; gap: 12px; align-items: center; max-width: min(1100px, 92vw); }
+.cookie-bar { position: fixed; bottom: 12px; left: 50%; transform: translateX(-50%); background: var(--panel); border: 1px solid var(--border); border-radius: 12px; padding: 14px; box-shadow: var(--shadow); display: flex; gap: 12px; align-items: center; max-width: min(1100px, 92vw); opacity: 0; pointer-events: none; transition: opacity 0.2s ease, transform 0.2s ease; }
+.cookie-bar.is-visible { opacity: 1; pointer-events: auto; transform: translateX(-50%) translateY(0); }
 .cookie-actions { display: flex; gap: 8px; flex-wrap: wrap; justify-content: flex-end; }
 
 .legal ul { padding-left: 18px; color: var(--text); }
@@ -205,7 +203,7 @@ label { font-weight: 700; }
 @media (max-width: 720px) {
   .site-header { flex-wrap: wrap; }
   .site-footer { position: static; }
-  body { padding-bottom: 0; }
+  body { padding-bottom: 120px; }
 }
 
 .favorite__button { background: var(--panel-muted); border: 1px solid var(--border); color: gold; border-radius: 50%; width: 38px; height: 38px; cursor: pointer; }

--- a/templates/base.html
+++ b/templates/base.html
@@ -61,7 +61,7 @@
     {% block content %}{% endblock %}
   </main>
 
-  <footer class="site-footer" data-pinned="false" data-collapsed="false">
+  <footer class="site-footer">
     <div class="footer-main">
       <div>
         Built for League fans. Artwork and champion data are property of Riot Games.
@@ -73,12 +73,7 @@
         <a href="{{ url_for('contact') }}">Contact</a>
       </div>
     </div>
-    <div class="footer-controls">
-      <button type="button" class="button ghost" id="footer-pin">Pin to bottom</button>
-      <button type="button" class="button ghost" id="footer-hide">Hide</button>
-    </div>
   </footer>
-  <button id="footer-show" class="button primary floating" hidden>Show footer</button>
   <div class="cookie-bar" id="cookie-bar" hidden>
     <div>
       League of Skins uses cookies to remember your preferences and keep navigation smooth. By continuing you agree to our cookie policy.
@@ -91,62 +86,35 @@
   <script>
     const toggle = document.getElementById('theme-toggle');
     const root = document.documentElement;
-    toggle?.addEventListener('click', () => {
-      const isLight = root.classList.toggle('theme-light');
-      localStorage.setItem('theme', isLight ? 'light' : 'dark');
-    });
+    const themeLabel = () => root.classList.contains('theme-light') ? '☀️ Light' : '🌙 Dark';
 
-    const footer = document.querySelector('.site-footer');
-    const footerPin = document.getElementById('footer-pin');
-    const footerHide = document.getElementById('footer-hide');
-    const footerShow = document.getElementById('footer-show');
+    if (toggle) {
+      toggle.textContent = themeLabel();
+      toggle.addEventListener('click', () => {
+        const isLight = root.classList.toggle('theme-light');
+        localStorage.setItem('theme', isLight ? 'light' : 'dark');
+        toggle.textContent = themeLabel();
+      });
+    }
+
     const cookieBar = document.getElementById('cookie-bar');
     const cookieAccept = document.getElementById('cookie-accept');
     const cookieDecline = document.getElementById('cookie-decline');
 
-    const footerPrefs = JSON.parse(localStorage.getItem('footerPrefs') || '{}');
-
-    function applyFooterPrefs() {
-      const pinned = footerPrefs.pinned;
-      const collapsed = footerPrefs.collapsed;
-      footer.dataset.pinned = pinned ? 'true' : 'false';
-      footer.dataset.collapsed = collapsed ? 'true' : 'false';
-      footerShow.hidden = !collapsed;
-      footerPin.textContent = pinned ? 'Unpin footer' : 'Pin to bottom';
-    }
-
-    applyFooterPrefs();
-
-    footerPin?.addEventListener('click', () => {
-      footerPrefs.pinned = !footerPrefs.pinned;
-      localStorage.setItem('footerPrefs', JSON.stringify(footerPrefs));
-      applyFooterPrefs();
-      footerPin.textContent = footerPrefs.pinned ? 'Unpin footer' : 'Pin to bottom';
-    });
-
-    footerHide?.addEventListener('click', () => {
-      footerPrefs.collapsed = true;
-      localStorage.setItem('footerPrefs', JSON.stringify(footerPrefs));
-      applyFooterPrefs();
-    });
-
-    footerShow?.addEventListener('click', () => {
-      footerPrefs.collapsed = false;
-      localStorage.setItem('footerPrefs', JSON.stringify(footerPrefs));
-      applyFooterPrefs();
-    });
-
     const consent = localStorage.getItem('cookieConsent');
-    if (!consent) {
+    if (cookieBar && !consent) {
       cookieBar.hidden = false;
+      cookieBar.classList.add('is-visible');
     }
     cookieAccept?.addEventListener('click', () => {
       localStorage.setItem('cookieConsent', 'accepted');
-      cookieBar.hidden = true;
+      cookieBar?.classList.remove('is-visible');
+      if (cookieBar) cookieBar.hidden = true;
     });
     cookieDecline?.addEventListener('click', () => {
       localStorage.setItem('cookieConsent', 'declined');
-      cookieBar.hidden = true;
+      cookieBar?.classList.remove('is-visible');
+      if (cookieBar) cookieBar.hidden = true;
     });
   </script>
 </body>

--- a/templates/champion.html
+++ b/templates/champion.html
@@ -20,20 +20,6 @@
 <section class="panel">
   <div class="panel__header">
     <div>
-      <p class="eyebrow">Quick jump</p>
-      <h2>Navigate skins faster</h2>
-    </div>
-  </div>
-  <div class="pill-list" style="grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));">
-    {% for skin in skins %}
-      <button class="pill" data-scroll-target="skin-{{ skin.skin_num }}">{{ skin.skin_name }}</button>
-    {% endfor %}
-  </div>
-</section>
-
-<section class="panel">
-  <div class="panel__header">
-    <div>
       <p class="eyebrow">Skins</p>
       <h2>{{ skins|length }} available skins</h2>
     </div>
@@ -57,14 +43,13 @@
               {{ 'Voted' if vote_data.voted else 'Vote' }}
             </button>
             <div class="vote__count" id="vote-count-{{ skin.skin_num }}">{{ vote_data.count }}</div>
-            <button class="favorite__button" data-favorite="{{ 'true' if vote_data.favorite else 'false' }}">{{ 'Saved' if vote_data.favorite else 'Save' }}</button>
+            <button class="favorite__button" data-favorite="{{ 'true' if vote_data.favorite else 'false' }}">{{ 'Saved ❤️' if vote_data.favorite else 'Save ❤️' }}</button>
           </div>
         </div>
         <div class="skin-card__actions">
           <a class="skin-link" target="_blank" rel="noopener" href="https://www.youtube.com/results?search_query={{ champ_name | urlencode }}+{{ skin.skin_name | urlencode }}+SkinSpotlights">
-            <span class="play-icon" aria-hidden="true"></span> Preview
+            ▶️ Preview
           </a>
-          <div class="muted">Opens a YouTube search in a new tab</div>
         </div>
       </article>
     {% endfor %}
@@ -150,7 +135,7 @@
         }
         const isAdded = data.status === 'added';
         btn.dataset.favorite = isAdded ? 'true' : 'false';
-        btn.textContent = isAdded ? 'Saved' : 'Save';
+        btn.textContent = isAdded ? 'Saved ❤️' : 'Save ❤️';
       } catch (err) {
         alert('Network error while updating favorite.');
       }
@@ -191,14 +176,6 @@
 
   modalNext?.addEventListener('click', () => stepModal(1));
   modalPrev?.addEventListener('click', () => stepModal(-1));
-
-  document.querySelectorAll('[data-scroll-target]').forEach(btn => {
-    btn.addEventListener('click', () => {
-      const targetId = btn.dataset.scrollTarget;
-      const target = document.getElementById(targetId);
-      target?.scrollIntoView({ behavior: 'smooth', block: 'start' });
-    });
-  });
 
   sortSkins();
 </script>

--- a/templates/contact.html
+++ b/templates/contact.html
@@ -33,43 +33,12 @@
       Contact email (optional)
       <input type="email" id="contact_email" name="contact_email" placeholder="you@example.com" />
     </label>
-    <div class="grid">
-      <label class="stack" for="server">
-        Server
-        <select id="server" name="server">
-          <option value="">Select server</option>
-          <option>NA</option>
-          <option>EUW</option>
-          <option>EUNE</option>
-          <option>LAN</option>
-          <option>LAS</option>
-          <option>BR</option>
-          <option>KR</option>
-          <option>JP</option>
-          <option>OCE</option>
-          <option>RU</option>
-          <option>TR</option>
-        </select>
-      </label>
-      <label class="stack" for="main_role">
-        Main role
-        <select id="main_role" name="main_role">
-          <option value="">Select role</option>
-          <option>Top</option>
-          <option>Jungle</option>
-          <option>Mid</option>
-          <option>ADC</option>
-          <option>Support</option>
-        </select>
-      </label>
-    </div>
     <label class="stack" for="message">
       Message
       <textarea id="message" name="message" rows="5" placeholder="How can we help?" required></textarea>
     </label>
     <button type="submit" class="button primary">Send message</button>
     <p class="muted">Signed-in users will be linked to their account automatically; emails stay private.</p>
-    <p class="muted">We collect server, role, and contact details to keep follow-ups organized and exportable.</p>
   </form>
 </section>
 {% endblock %}

--- a/templates/register.html
+++ b/templates/register.html
@@ -14,30 +14,6 @@
       <input type="password" name="password" placeholder="At least 8 characters" required />
       <label>Confirm password</label>
       <input type="password" name="password_confirm" placeholder="Re-enter password" required />
-      <div class="grid">
-        <label class="stack" for="server">
-          Server
-          <select id="server" name="server">
-            <option value="">Select server</option>
-            {% for opt in ['NA','EUW','EUNE','LAN','LAS','BR','KR','JP','OCE','RU','TR'] %}
-              <option value="{{ opt }}">{{ opt }}</option>
-            {% endfor %}
-          </select>
-        </label>
-        <label class="stack" for="main_role">
-          Main role
-          <select id="main_role" name="main_role">
-            <option value="">Select role</option>
-            {% for role in ['Top','Jungle','Mid','ADC','Support'] %}
-              <option value="{{ role }}">{{ role }}</option>
-            {% endfor %}
-          </select>
-        </label>
-      </div>
-      <label class="stack" for="favorite_champion">
-        Favorite champion
-        <input type="text" id="favorite_champion" name="favorite_champion" placeholder="e.g., Aatrox" />
-      </label>
       <button type="submit" class="button primary full">Create account</button>
     </form>
     <p class="muted">Already have an account? <a href="{{ url_for('login') }}">Log in</a>.</p>

--- a/users_db.json
+++ b/users_db.json
@@ -1,23 +1,14 @@
 {
-    "majd@majd.com": {
-        "password": "scrypt:32768:8:1$DJS7x7NM5uPSZqTD$ed394276c398175f1801f0226aaa7776ce06bcde66aee41c0131b4b43b371391a0e8edc4641796999e1ea81daba39d6c3d4d8241959485e5ab743458b4dc2e02",
-        "verified": true,
-        "token": "c1ce3642-1732-4734-8851-d4cd3120439a",
-        "username": "majd",
-        "main_champion": "",
-        "favorites": []
-    },
     "abdallhhelles97@gmail.com": {
-        "password": "scrypt:32768:8:1$NzYdmZsge7xfiV1T$99463361f56d6ef9ee7095d0f6b562683eabdcc17ce6c40aa801cf786250037bf5f8b0de906460c1317bad2265da762a0142d96c39767844e4e412c5f4793129",
+        "password": "scrypt:32768:8:1$zURTkB75TknNe0qZ$ca19c22df5ac3561783756881b5e8fb046d00c83198c8d8ac83678235e2e2568eb89059fa90a6d0a085e0fd33b877807f97437d05ba43b5ec59dafa6bae84341",
         "verified": true,
-        "token": ""
-    },
-    "a@a.com": {
-        "password": "scrypt:32768:8:1$Tt8NAA6ASsLOx7NO$5662ad0ab9310d16c5d4ab1a119fe665ebc608adeb4c2a98ab09785fe4b734e21d760dccc074c7222c04c0bc19e5651b46a513e617cc48c3f11f20517ac07e05",
-        "verified": true,
-        "token": "df994c1a-413e-456b-aa91-1dbd5ec0dc86",
-        "username": "a",
+        "token": "",
+        "username": "admin",
         "main_champion": "",
-        "favorites": []
+        "favorite_champion": "",
+        "favorites": [],
+        "reset_token": "",
+        "server": "",
+        "main_role": ""
     }
 }


### PR DESCRIPTION
## Summary
- Fix the footer to stay pinned, improve cookie consent visibility, and restore emoji-based theme toggle
- Simplify champion skin actions by removing quick jump and unprofessional copy while restoring emoji icons
- Streamline contact/registration forms, seed a clean admin account, and keep profile management on the dedicated page

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695af377bb18832bac069e37dd7ae751)