### PR TITLE
Add comment threading, vote toggles, and notifications

### DIFF
--- a/app.py
+++ b/app.py
@@ -102,10 +102,17 @@ def get_display_name(email: str) -> str:
 
 @app.context_processor
 def inject_globals():
+    user_email = session.get('email')
+    unread_notifications = 0
+    if user_email:
+        profile = users.get(user_email, {})
+        notifications = profile.get('notifications', [])
+        unread_notifications = sum(1 for note in notifications if not note.get('read'))
     return {
         "ADMIN_EMAIL": ADMIN_EMAIL,
         "users": users,
         "current_year": datetime.utcnow().year,
+        "unread_notifications": unread_notifications,
     }
 
 
@@ -190,8 +197,47 @@ def hydrate_user_profiles():
         if 'favorite_champion' not in profile:
             profile['favorite_champion'] = ''
             changed = True
+        if 'notifications' not in profile:
+            profile['notifications'] = []
+            changed = True
     if changed:
         save_users(users)
+
+
+def add_notification(user_email, message, link, champion=None):
+    profile = users.get(user_email)
+    if not profile:
+        return
+    notification = {
+        'id': str(uuid.uuid4()),
+        'message': message,
+        'link': link,
+        'read': False,
+        'created_at': datetime.utcnow().isoformat(),
+        'champion': champion or '',
+    }
+    profile.setdefault('notifications', []).append(notification)
+    save_users(users)
+
+
+def mark_champion_notifications_read(user_email, champion):
+    profile = users.get(user_email)
+    if not profile:
+        return []
+    notifications = profile.get('notifications', [])
+    relevant = []
+    for note in notifications:
+        if note.get('champion') == champion and not note.get('read'):
+            note['read'] = True
+            relevant.append(note)
+    if relevant:
+        save_users(users)
+    return relevant
+
+
+def get_unread_notifications(user_email):
+    profile = users.get(user_email, {})
+    return [note for note in profile.get('notifications', []) if not note.get('read')]
 
 
 def bootstrap_splash_assets():
@@ -297,6 +343,33 @@ def compute_user_karma(user_email):
     return score
 
 
+def prepare_comment_threads(champ_comments):
+    enriched = {}
+    for comment in champ_comments:
+        copy = {**comment}
+        copy['upvotes'] = len(copy.get('upvoters', []))
+        copy['downvotes'] = len(copy.get('downvoters', []))
+        copy['score'] = copy['upvotes'] - copy['downvotes']
+        copy['replies'] = []
+        enriched[copy['id']] = copy
+
+    roots = []
+    for comment in enriched.values():
+        parent_id = comment.get('parent_id')
+        if parent_id and parent_id in enriched:
+            enriched[parent_id]['replies'].append(comment)
+        else:
+            roots.append(comment)
+
+    def sort_comments(items):
+        items.sort(key=lambda c: (c.get('score', 0), c.get('created_at', '')), reverse=True)
+        for item in items:
+            sort_comments(item['replies'])
+
+    sort_comments(roots)
+    return roots
+
+
 def top_voted_skins(all_champions, limit=20):
     """Return a list of the top voted skins with their metadata."""
 
@@ -379,6 +452,16 @@ def champion_page(champ_name):
     if not champ_skins:
         return "Champion not found", 404
 
+    champion_names = sorted(all_champions.keys(), key=lambda name: name.lower())
+    prev_champ = None
+    next_champ = None
+    if champ_name in champion_names:
+        idx = champion_names.index(champ_name)
+        if idx > 0:
+            prev_champ = champion_names[idx - 1]
+        if idx < len(champion_names) - 1:
+            next_champ = champion_names[idx + 1]
+
     champion_lore = fetch_champion_lore(champ_name)
 
     user_email = session.get('email')
@@ -398,18 +481,18 @@ def champion_page(champ_name):
         }
 
     champ_comments = comments.get(champ_name, [])
-    # Sort comments by karma then recency
-    sorted_comments = sorted(
-        champ_comments,
-        key=lambda c: (len(c.get("upvoters", [])) - len(c.get("downvoters", [])), c.get("created_at", "")),
-        reverse=True,
-    )
-    enriched_comments = []
-    for comment in sorted_comments:
-        enriched_comments.append({
-            **comment,
-            'display_name': get_display_name(comment.get('author', '')),
-        })
+    threaded_comments = prepare_comment_threads(champ_comments)
+
+    def attach_display(items):
+        for item in items:
+            item['display_name'] = get_display_name(item.get('author', ''))
+            attach_display(item['replies'])
+
+    attach_display(threaded_comments)
+
+    champ_notifications = []
+    if user_email:
+        champ_notifications = mark_champion_notifications_read(user_email, champ_name)
 
     return render_template(
         'champion.html',
@@ -417,11 +500,37 @@ def champion_page(champ_name):
         skins=champ_skins,
         user=user_email,
         champ_votes=champ_votes,
-        comments=enriched_comments,
+        comments=threaded_comments,
         karma=user_karma,
         favorites=favorites,
         champion_lore=champion_lore,
+        prev_champ=prev_champ,
+        next_champ=next_champ,
+        champ_notifications=champ_notifications,
     )
+
+
+@app.route('/notifications')
+def notifications_page():
+    user_email = session.get('email')
+    if not user_email:
+        flash('Log in to view notifications.')
+        return redirect(url_for('login'))
+
+    profile = users.get(user_email, {})
+    notifications = sorted(profile.get('notifications', []), key=lambda n: n.get('created_at', ''), reverse=True)
+    changed = False
+    for note in notifications:
+        if not note.get('link'):
+            note['link'] = url_for('index')
+            changed = True
+        if not note.get('read'):
+            note['read'] = True
+            changed = True
+    if changed:
+        save_users(users)
+
+    return render_template('notifications.html', notifications=notifications)
 
 
 @app.route('/top')
@@ -564,6 +673,9 @@ def vote_skin(champ_name, skin_id):
     user_email = session['email']
     all_champions = load_all_skins()
 
+    payload = request.get_json(silent=True) or {}
+    action = payload.get('action', 'add')
+
     # Verify champion exists
     champ_skins = all_champions.get(champ_name)
     if not champ_skins:
@@ -586,17 +698,24 @@ def vote_skin(champ_name, skin_id):
 
     skin_vote_data = votes[vote_key]
 
-    # Prevent double voting
-    if user_email in skin_vote_data["voters"]:
-        return jsonify({'error': 'You already voted for this skin.'}), 403
+    if action == 'remove':
+        if user_email not in skin_vote_data["voters"]:
+            return jsonify({'error': 'You have not voted for this skin yet.'}), 400
+        skin_vote_data["voters"].remove(user_email)
+        skin_vote_data["count"] = max(0, skin_vote_data["count"] - 1)
+        status = 'removed'
+    else:
+        # Prevent double voting
+        if user_email in skin_vote_data["voters"]:
+            return jsonify({'error': 'You already voted for this skin.'}), 403
 
-    # Register the vote
-    skin_vote_data["count"] += 1
-    skin_vote_data["voters"].append(user_email)
+        skin_vote_data["count"] += 1
+        skin_vote_data["voters"].append(user_email)
+        status = 'added'
 
     save_votes(votes)
 
-    return jsonify({'votes': skin_vote_data["count"]})
+    return jsonify({'votes': skin_vote_data["count"], 'status': status})
 
 
 @app.route('/favorite/<champ_name>/<skin_id>', methods=['POST'])
@@ -635,9 +754,17 @@ def add_comment(champ_name):
 
     payload = request.get_json(force=True)
     text = (payload.get('text') or '').strip()
+    parent_id = payload.get('parent_id')
 
     if not text:
         return jsonify({'error': 'Comment cannot be empty.'}), 400
+
+    parent_comment = None
+    if parent_id:
+        champ_comments = comments.get(champ_name, [])
+        parent_comment = next((c for c in champ_comments if c.get('id') == parent_id), None)
+        if not parent_comment:
+            return jsonify({'error': 'Parent comment not found.'}), 404
 
     new_comment = {
         "id": str(uuid.uuid4()),
@@ -646,11 +773,20 @@ def add_comment(champ_name):
         "upvoters": [],
         "downvoters": [],
         "created_at": uuid.uuid1().hex,
+        "parent_id": parent_id,
     }
 
     champ_comments = comments.setdefault(champ_name, [])
     champ_comments.append(new_comment)
     save_comments(comments)
+
+    if parent_comment and parent_comment.get('author') and parent_comment.get('author') != user_email:
+        try:
+            link = url_for('champion_page', champ_name=champ_name) + f"#comment-{new_comment['id']}"
+            message = f"{get_display_name(user_email)} replied to your comment on {champ_name}."
+            add_notification(parent_comment['author'], message, link, champion=champ_name)
+        except Exception:
+            pass
 
     return jsonify({
         'id': new_comment['id'],
@@ -660,6 +796,7 @@ def add_comment(champ_name):
         'upvotes': 0,
         'downvotes': 0,
         'score': 0,
+        'parent_id': parent_id,
     }), 201
 
 

--- a/static/styles.css
+++ b/static/styles.css
@@ -41,19 +41,20 @@
 body {
   margin: 0;
   min-height: 100vh;
+  display: flex;
+  flex-direction: column;
   background: radial-gradient(circle at 20% 20%, rgba(245,210,123,0.05), transparent 25%),
               radial-gradient(circle at 80% 0%, rgba(212,175,55,0.08), transparent 30%),
               var(--bg);
   color: var(--text);
   font-family: var(--font);
   line-height: 1.6;
-  padding-bottom: 160px;
 }
 
 a { color: var(--accent-strong); text-decoration: none; }
 a:hover { color: var(--accent); }
 
-main { width: min(1200px, 94vw); margin: 32px auto 0; display: flex; flex-direction: column; gap: 28px; }
+main { width: min(1200px, 94vw); margin: 32px auto 0; display: flex; flex-direction: column; gap: 28px; flex: 1; }
 
 .site-header {
   position: sticky; top: 0; z-index: 10;
@@ -123,15 +124,16 @@ main { width: min(1200px, 94vw); margin: 32px auto 0; display: flex; flex-direct
 
 .page-header { background: var(--panel); border: 1px solid var(--border); border-radius: var(--radius); padding: 20px; box-shadow: var(--shadow); display: flex; justify-content: space-between; gap: 12px; align-items: flex-start; flex-wrap: wrap; }
 .breadcrumb { color: var(--muted); display: flex; gap: 8px; align-items: center; }
+.champion-nav { display: flex; gap: 10px; align-items: center; flex-wrap: wrap; }
 
 .skins-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 14px; }
-.skin-card { background: var(--panel-muted); border: 1px solid var(--border); border-radius: 12px; overflow: hidden; box-shadow: var(--shadow); display: flex; flex-direction: column; }
+.skin-card { background: var(--panel-muted); border: 1px solid var(--border); border-radius: 12px; overflow: hidden; box-shadow: var(--shadow); display: grid; grid-template-rows: auto 1fr auto; }
 .skin-card__image { height: 170px; background-size: cover; background-position: center; border: none; width: 100%; cursor: pointer; }
 .skin-card__image:hover { filter: brightness(1.05); }
-.skin-card__body { padding: 14px; display: flex; align-items: center; justify-content: space-between; gap: 10px; }
-.skin-card__title { margin: 4px 0 0; font-size: 18px; }
-.skin-card__actions { display: flex; align-items: center; justify-content: space-between; padding: 0 14px 14px; gap: 10px; flex-wrap: wrap; }
-.vote { display: flex; align-items: center; gap: 10px; }
+.skin-card__body { padding: 14px; display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; min-height: 120px; }
+.skin-card__title { margin: 4px 0 0; font-size: 18px; line-height: 1.3; }
+.skin-card__actions { display: flex; align-items: center; justify-content: space-between; padding: 0 14px 14px; gap: 10px; flex-wrap: wrap; margin-top: auto; }
+.vote { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; justify-content: flex-end; }
 .vote__button { background: linear-gradient(135deg, rgba(212,175,55,0.15), rgba(245,210,123,0.05)); border: 1px solid var(--border); color: var(--accent-strong); border-radius: 10px; min-width: 86px; height: 40px; font-size: 14px; cursor: pointer; transition: all 0.2s ease; font-weight: 800; }
 .vote__button:hover:not([disabled]) { transform: translateY(-1px); border-color: var(--accent); }
 .vote__button:disabled { opacity: 0.6; cursor: not-allowed; }
@@ -166,7 +168,7 @@ main { width: min(1200px, 94vw); margin: 32px auto 0; display: flex; flex-direct
 label { font-weight: 700; }
 .muted { color: var(--muted); }
 
-.site-footer { width: 100%; padding: 18px 3vw; border-top: 1px solid var(--border); color: var(--muted); background: var(--panel); display: flex; justify-content: space-between; align-items: center; gap: 10px; flex-wrap: wrap; position: fixed; left: 0; bottom: 0; box-shadow: var(--shadow); z-index: 10; }
+.site-footer { width: 100%; padding: 18px 3vw; border-top: 1px solid var(--border); color: var(--muted); background: var(--panel); display: flex; justify-content: space-between; align-items: center; gap: 10px; flex-wrap: wrap; position: static; box-shadow: var(--shadow); z-index: 1; margin-top: 32px; }
 .footer-links { display: flex; gap: 12px; flex-wrap: wrap; align-items: center; }
 .footer-main { display: flex; flex-direction: column; gap: 6px; }
 .footer-brand { color: var(--text); font-weight: 700; }
@@ -198,14 +200,25 @@ label { font-weight: 700; }
 .comment__header { display: flex; align-items: center; justify-content: space-between; gap: 8px; margin-bottom: 6px; }
 .comment__author { font-weight: 700; }
 .comment__meta { color: var(--muted); font-size: 14px; }
-.comment__actions { display: flex; gap: 8px; margin-top: 8px; }
+.comment__actions { display: flex; gap: 8px; margin-top: 8px; flex-wrap: wrap; align-items: center; }
 .comment__vote { border: 1px solid var(--border); background: var(--panel-muted); color: var(--text); border-radius: 8px; padding: 6px 10px; cursor: pointer; }
 .comment__vote:hover { border-color: var(--accent); color: white; }
+.comment__text { margin: 4px 0 0; }
+.comment__replies { border-left: 2px solid var(--border); margin-left: 14px; padding-left: 12px; display: grid; gap: 12px; }
+.reply-form { margin-top: 8px; display: grid; gap: 8px; }
+.reply-form textarea { width: 100%; border: 1px solid var(--border); background: var(--panel-muted); color: var(--text); padding: 10px; border-radius: 10px; }
+.reply-form__actions { display: flex; gap: 8px; flex-wrap: wrap; }
+.notice { border: 1px solid var(--border); background: var(--panel-muted); border-radius: 12px; padding: 12px; box-shadow: var(--shadow); }
+.notice--card { display: grid; gap: 6px; }
+.notice__title { font-weight: 800; color: var(--text); }
+.notice__meta { color: var(--muted); font-size: 14px; }
+.notice__list { margin: 8px 0 0; padding-left: 18px; color: var(--text); display: grid; gap: 6px; }
+.notice-list { display: grid; gap: 12px; }
+.emoji-mono { filter: grayscale(1); color: currentColor; }
 
 @media (max-width: 720px) {
   .site-header { flex-wrap: wrap; }
   .site-footer { position: static; }
-  body { padding-bottom: 120px; }
 }
 
 .favorite__button { background: var(--panel-muted); border: 1px solid var(--border); color: var(--text); border-radius: 10px; padding: 8px 12px; cursor: pointer; font-weight: 700; }

--- a/templates/base.html
+++ b/templates/base.html
@@ -37,6 +37,7 @@
       <button class="button ghost toggle" id="theme-toggle" type="button" aria-label="Toggle theme">Theme</button>
       {% if session.email %}
         <div class="welcome">Hi, {{ users[session.email].username if session.email in users else session.email.split('@')[0] }}</div>
+        <a class="button ghost" href="{{ url_for('notifications_page') }}">Notifications{% if unread_notifications %} ({{ unread_notifications }}){% endif %}</a>
         <a class="button ghost" href="{{ url_for('profile') }}">Profile</a>
         <a class="button ghost" href="{{ url_for('logout') }}">Logout</a>
       {% else %}

--- a/templates/champion.html
+++ b/templates/champion.html
@@ -15,6 +15,18 @@
     <span aria-hidden="true">/</span>
     <span>{{ champ_name }}</span>
   </div>
+  <div class="champion-nav">
+    {% if prev_champ %}
+      <a class="button ghost" href="{{ url_for('champion_page', champ_name=prev_champ) }}" aria-label="Previous champion">
+        ← {{ prev_champ }}
+      </a>
+    {% endif %}
+    {% if next_champ %}
+      <a class="button ghost" href="{{ url_for('champion_page', champ_name=next_champ) }}" aria-label="Next champion">
+        {{ next_champ }} →
+      </a>
+    {% endif %}
+  </div>
 </section>
 
 <section class="panel">
@@ -35,15 +47,14 @@
         <button class="skin-card__image" style="background-image:url('{{ url_for('static', filename=skin.file_path) }}');" aria-label="View {{ skin.skin_name }} splash" data-modal-src="{{ url_for('static', filename=skin.file_path) }}"></button>
         <div class="skin-card__body">
           <div>
-            <p class="eyebrow">{{ champ_name }}</p>
             <h3 class="skin-card__title">{{ skin.skin_name }}</h3>
           </div>
           <div class="vote">
-            <button class="vote__button" {% if vote_data.voted %}disabled{% endif %}>
-              {{ 'Voted' if vote_data.voted else 'Vote' }}
+            <button class="vote__button" data-voted="{{ 'true' if vote_data.voted else 'false' }}">
+              {{ 'Remove vote' if vote_data.voted else 'Vote' }}
             </button>
             <div class="vote__count" id="vote-count-{{ skin.skin_num }}">{{ vote_data.count }}</div>
-            <button class="favorite__button" data-favorite="{{ 'true' if vote_data.favorite else 'false' }}">{{ 'Saved ❤️' if vote_data.favorite else 'Save ❤️' }}</button>
+            <button class="favorite__button" data-favorite="{{ 'true' if vote_data.favorite else 'false' }}">{{ 'Saved ' if vote_data.favorite else 'Save ' }}<span class="emoji-mono" aria-hidden="true">♥</span></button>
           </div>
         </div>
           <div class="skin-card__actions">
@@ -94,18 +105,22 @@
       const card = e.target.closest('.skin-card');
       const skinId = card.dataset.skinId;
       const champName = card.dataset.champName;
+      const action = btn.dataset.voted === 'true' ? 'remove' : 'add';
 
       try {
         const response = await fetch(`/vote/${encodeURIComponent(champName)}/${encodeURIComponent(skinId)}`, {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' }
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ action })
         });
 
         if (response.ok) {
           const data = await response.json();
           const countEl = card.querySelector('.vote__count');
           countEl.textContent = data.votes;
-          btn.disabled = true;
+          const isVoted = data.status === 'added';
+          btn.dataset.voted = isVoted ? 'true' : 'false';
+          btn.textContent = isVoted ? 'Remove vote' : 'Vote';
           sortSkins();
         } else {
           const error = await response.json();
@@ -135,7 +150,7 @@
         }
         const isAdded = data.status === 'added';
         btn.dataset.favorite = isAdded ? 'true' : 'false';
-        btn.textContent = isAdded ? 'Saved ❤️' : 'Save ❤️';
+        btn.innerHTML = isAdded ? 'Saved <span class="emoji-mono" aria-hidden="true">♥</span>' : 'Save <span class="emoji-mono" aria-hidden="true">♥</span>';
       } catch (err) {
         alert('Network error while updating favorite.');
       }
@@ -194,6 +209,17 @@
     {% endif %}
   </div>
 
+  {% if champ_notifications %}
+    <div class="notice">
+      <div class="notice__title">New replies to your comments</div>
+      <ul class="notice__list">
+        {% for note in champ_notifications %}
+          <li><a href="{{ note.link }}">{{ note.message }}</a></li>
+        {% endfor %}
+      </ul>
+    </div>
+  {% endif %}
+
   {% if session.email %}
     <form class="comment-form" id="comment-form">
       <label for="comment-text" class="eyebrow">Add a comment</label>
@@ -202,28 +228,98 @@
     </form>
   {% endif %}
 
+  {% macro render_comment(comment) %}
+    <article class="comment" data-comment-id="{{ comment.id }}" id="comment-{{ comment.id }}">
+      <div class="comment__header">
+        <div class="comment__author">{{ comment.display_name }}</div>
+        <div class="comment__meta">Karma: <span class="comment__score">{{ comment.score }}</span></div>
+      </div>
+      <p class="comment__text">{{ comment.text }}</p>
+      <div class="comment__actions">
+        <button class="comment__vote" data-direction="up"><span class="emoji-mono" aria-hidden="true">▲</span> {{ comment.upvotes }}</button>
+        <button class="comment__vote" data-direction="down"><span class="emoji-mono" aria-hidden="true">▼</span> {{ comment.downvotes }}</button>
+        {% if session.email %}
+          <button class="comment__reply" type="button">Reply</button>
+        {% endif %}
+      </div>
+      {% if session.email %}
+        <form class="reply-form" hidden>
+          <textarea rows="2" required placeholder="Write a reply"></textarea>
+          <div class="reply-form__actions">
+            <button type="submit" class="button primary">Post reply</button>
+            <button type="button" class="button ghost reply-cancel">Cancel</button>
+          </div>
+        </form>
+      {% endif %}
+      {% if comment.replies %}
+        <div class="comment__replies">
+          {% for reply in comment.replies %}
+            {{ render_comment(reply) }}
+          {% endfor %}
+        </div>
+      {% endif %}
+    </article>
+  {% endmacro %}
+
   <div id="comment-list" class="comment-list">
-    {% for comment in comments %}
-      <article class="comment" data-comment-id="{{ comment.id }}">
-        <div class="comment__header">
-          <div class="comment__author">{{ comment.display_name }}</div>
-          <div class="comment__meta">Karma: <span class="comment__score">{{ comment.upvoters|length - comment.downvoters|length }}</span></div>
-        </div>
-        <p>{{ comment.text }}</p>
-        <div class="comment__actions">
-          <button class="comment__vote" data-direction="up">Upvote {{ comment.upvoters|length }}</button>
-          <button class="comment__vote" data-direction="down">Downvote {{ comment.downvoters|length }}</button>
-        </div>
-      </article>
+    {% if comments %}
+      {% for comment in comments %}
+        {{ render_comment(comment) }}
+      {% endfor %}
     {% else %}
       <p class="muted">No comments yet. Start the conversation.</p>
-    {% endfor %}
+    {% endif %}
   </div>
 </section>
 
 <script>
   const commentForm = document.getElementById('comment-form');
   const commentList = document.getElementById('comment-list');
+  const canReply = {{ (session.email is not none)|tojson }};
+
+  const escapeHtml = (unsafe) => {
+    return unsafe
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#039;");
+  };
+
+  const buildComment = (data) => {
+    const article = document.createElement('article');
+    article.className = 'comment';
+    article.dataset.commentId = data.id;
+    article.id = `comment-${data.id}`;
+    article.innerHTML = `
+      <div class="comment__header">
+        <div class="comment__author">${escapeHtml(data.display_name || data.author || 'Anonymous')}</div>
+        <div class="comment__meta">Karma: <span class="comment__score">${data.score ?? 0}</span></div>
+      </div>
+      <p class="comment__text">${escapeHtml(data.text || '')}</p>
+      <div class="comment__actions">
+        <button class="comment__vote" data-direction="up"><span class="emoji-mono" aria-hidden="true">▲</span> ${data.upvotes ?? 0}</button>
+        <button class="comment__vote" data-direction="down"><span class="emoji-mono" aria-hidden="true">▼</span> ${data.downvotes ?? 0}</button>
+        ${canReply ? '<button class="comment__reply" type="button">Reply</button>' : ''}
+      </div>
+      ${canReply ? `
+        <form class="reply-form" hidden>
+          <textarea rows="2" required placeholder="Write a reply"></textarea>
+          <div class="reply-form__actions">
+            <button type="submit" class="button primary">Post reply</button>
+            <button type="button" class="button ghost reply-cancel">Cancel</button>
+          </div>
+        </form>` : ''}
+      <div class="comment__replies"></div>
+    `;
+
+    if (Array.isArray(data.replies)) {
+      const repliesContainer = article.querySelector('.comment__replies');
+      data.replies.forEach(reply => repliesContainer.appendChild(buildComment(reply)));
+    }
+
+    return article;
+  };
 
   if (commentForm) {
     commentForm.addEventListener('submit', async (e) => {
@@ -245,21 +341,7 @@
           return;
         }
 
-        const article = document.createElement('article');
-        article.className = 'comment';
-        article.dataset.commentId = data.id;
-        article.innerHTML = `
-          <div class="comment__header">
-            <div class="comment__author">${data.display_name || data.author}</div>
-            <div class="comment__meta">Karma: <span class="comment__score">${data.score}</span></div>
-          </div>
-          <p>${data.text}</p>
-          <div class="comment__actions">
-            <button class="comment__vote" data-direction="up">Upvote ${data.upvotes}</button>
-            <button class="comment__vote" data-direction="down">Downvote ${data.downvotes}</button>
-          </div>
-        `;
-
+        const article = buildComment(data);
         commentList.prepend(article);
         textArea.value = '';
       } catch (err) {
@@ -269,6 +351,27 @@
   }
 
   commentList?.addEventListener('click', async (e) => {
+    const replyBtn = e.target.closest('.comment__reply');
+    if (replyBtn) {
+      const comment = replyBtn.closest('.comment');
+      const form = comment.querySelector('.reply-form');
+      if (form) {
+        form.hidden = false;
+        form.querySelector('textarea')?.focus();
+      }
+      return;
+    }
+
+    const cancelBtn = e.target.closest('.reply-cancel');
+    if (cancelBtn) {
+      const form = cancelBtn.closest('.reply-form');
+      if (form) {
+        form.hidden = true;
+        form.reset();
+      }
+      return;
+    }
+
     const voteBtn = e.target.closest('.comment__vote');
     if (!voteBtn) return;
 
@@ -290,13 +393,50 @@
 
       const [upBtn, downBtn] = comment.querySelectorAll('.comment__vote');
       if (upBtn && downBtn) {
-        upBtn.textContent = `Upvote ${data.upvotes}`;
-        downBtn.textContent = `Downvote ${data.downvotes}`;
+        upBtn.innerHTML = `<span class="emoji-mono" aria-hidden="true">▲</span> ${data.upvotes}`;
+        downBtn.innerHTML = `<span class="emoji-mono" aria-hidden="true">▼</span> ${data.downvotes}`;
       }
       const scoreEl = comment.querySelector('.comment__score');
       if (scoreEl) scoreEl.textContent = data.score;
     } catch (err) {
       alert('Network error while voting on comment.');
+    }
+  });
+
+  commentList?.addEventListener('submit', async (e) => {
+    const replyForm = e.target.closest('.reply-form');
+    if (!replyForm) return;
+
+    e.preventDefault();
+    const textArea = replyForm.querySelector('textarea');
+    const text = textArea.value.trim();
+    if (!text) return;
+
+    const parent = replyForm.closest('.comment');
+    const commentId = parent?.dataset.commentId;
+
+    try {
+      const response = await fetch(`/comment/${champSlug}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text, parent_id: commentId })
+      });
+
+      const data = await response.json();
+      if (!response.ok) {
+        alert(data.error || 'Unable to post reply.');
+        return;
+      }
+
+      const repliesContainer = parent?.querySelector('.comment__replies');
+      const replyNode = buildComment(data);
+      if (repliesContainer) {
+        repliesContainer.prepend(replyNode);
+      }
+      replyForm.reset();
+      replyForm.hidden = true;
+    } catch (err) {
+      alert('Network error while posting reply.');
     }
   });
 </script>

--- a/templates/notifications.html
+++ b/templates/notifications.html
@@ -1,0 +1,33 @@
+{% extends 'base.html' %}
+{% block title %}Notifications | League of Skins{% endblock %}
+{% block content %}
+<section class="page-header">
+  <div>
+    <p class="eyebrow">Notifications</p>
+    <h1>Your latest updates</h1>
+    <p class="lede">Replies to your comments and other important updates appear here.</p>
+  </div>
+</section>
+
+<section class="panel">
+  <div class="panel__header">
+    <div>
+      <p class="eyebrow">Inbox</p>
+      <h2>{{ notifications|length }} notification{{ 's' if notifications|length != 1 else '' }}</h2>
+    </div>
+  </div>
+  <div class="notice-list">
+    {% if notifications %}
+      {% for note in notifications %}
+        <article class="notice notice--card">
+          <div class="notice__title">{{ note.message }}</div>
+          <div class="notice__meta">{{ note.created_at }}</div>
+          <a class="skin-link" href="{{ note.link }}">View</a>
+        </article>
+      {% endfor %}
+    {% else %}
+      <p class="muted">You're all caught up.</p>
+    {% endif %}
+  </div>
+</section>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add threaded comment replies with monochrome voting icons and reply notifications
- allow toggling skin votes and standardize skin card layout with prev/next champion navigation
- introduce a notifications hub, monochrome emoji styling, and footer positioning updates

## Testing
- python -m compileall app.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695afe2ea6b0832b9ed89da57ace343a)