### PR TITLE
Simplify navigation and voting UI

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -134,7 +134,8 @@ main { width: min(1200px, 94vw); margin: 32px auto 0; display: flex; flex-direct
 .list-card { background: var(--panel-muted); border: 1px solid var(--border); border-radius: 12px; padding: 12px; display: grid; gap: 8px; }
 .list-card__item { color: var(--text); font-weight: 600; }
 
-.page-header { background: var(--panel); border: 1px solid var(--border); border-radius: var(--radius); padding: 20px; box-shadow: var(--shadow); display: flex; justify-content: space-between; gap: 12px; align-items: flex-start; flex-wrap: wrap; }
+.page-header { background: var(--panel); border: 1px solid var(--border); border-radius: var(--radius); padding: 22px; box-shadow: var(--shadow); display: flex; justify-content: space-between; gap: 16px; align-items: center; flex-wrap: wrap; }
+.page-header > div:first-child { flex: 1; min-width: 260px; }
 .breadcrumb { color: var(--muted); display: flex; gap: 8px; align-items: center; }
 .champion-nav { display: flex; gap: 10px; align-items: center; flex-wrap: wrap; }
 
@@ -146,7 +147,7 @@ main { width: min(1200px, 94vw); margin: 32px auto 0; display: flex; flex-direct
 .skin-card__title { margin: 4px 0 0; font-size: 18px; line-height: 1.3; }
 .skin-card__actions { display: flex; align-items: center; justify-content: space-between; padding: 0 14px 14px; gap: 10px; flex-wrap: wrap; margin-top: auto; }
 .vote { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; justify-content: flex-end; }
-.vote__button { background: linear-gradient(135deg, rgba(212,175,55,0.15), rgba(245,210,123,0.05)); border: 1px solid var(--border); color: var(--accent-strong); border-radius: 10px; min-width: 86px; height: 40px; font-size: 14px; cursor: pointer; transition: all 0.2s ease; font-weight: 800; }
+.vote__button { background: linear-gradient(135deg, rgba(212,175,55,0.15), rgba(245,210,123,0.05)); border: 1px solid var(--border); color: var(--accent-strong); border-radius: 10px; min-width: 96px; height: 40px; font-size: 14px; cursor: pointer; transition: all 0.2s ease; font-weight: 800; padding: 0 14px; }
 .vote__button:hover:not([disabled]) { transform: translateY(-1px); border-color: var(--accent); }
 .vote__button:disabled { opacity: 0.6; cursor: not-allowed; }
 .vote__count { font-weight: 800; font-size: 20px; }

--- a/templates/base.html
+++ b/templates/base.html
@@ -27,14 +27,14 @@
     <nav class="site-nav">
       <a href="{{ url_for('index') }}">Champions</a>
       <a href="{{ url_for('top_skins') }}">Top voted</a>
-      <a href="{{ url_for('about_page') }}">About</a>
-      <a href="{{ url_for('contact') }}">Contact</a>
       {% if session.email == ADMIN_EMAIL %}
         <a href="{{ url_for('admin_dashboard') }}">Admin</a>
       {% endif %}
     </nav>
     <div class="auth">
-      <button class="button ghost toggle" id="theme-toggle" type="button" aria-label="Toggle theme">Theme</button>
+      <button class="button ghost toggle" id="theme-toggle" type="button" aria-label="Toggle theme">
+        <span class="emoji-mono" aria-hidden="true">☾</span>
+      </button>
       {% if session.email %}
         <div class="welcome">Hi, {{ users[session.email].username if session.email in users else session.email.split('@')[0] }}</div>
         <a class="button ghost" href="{{ url_for('notifications_page') }}">Notifications{% if unread_notifications %} ({{ unread_notifications }}){% endif %}</a>
@@ -86,14 +86,18 @@
   <script>
     const toggle = document.getElementById('theme-toggle');
     const root = document.documentElement;
-    const themeLabel = () => root.classList.contains('theme-light') ? '☀ Light' : '☾ Dark';
+
+    const updateThemeToggle = () => {
+      const isLight = root.classList.contains('theme-light');
+      toggle.innerHTML = `<span class="emoji-mono" aria-hidden="true">${isLight ? '☀' : '☾'}</span>`;
+    };
 
     if (toggle) {
-      toggle.innerHTML = `<span class="emoji-mono" aria-hidden="true">${root.classList.contains('theme-light') ? '☀' : '☾'}</span> ${themeLabel().split(' ')[1]}`;
+      updateThemeToggle();
       toggle.addEventListener('click', () => {
         const isLight = root.classList.toggle('theme-light');
         localStorage.setItem('theme', isLight ? 'light' : 'dark');
-        toggle.innerHTML = `<span class="emoji-mono" aria-hidden="true">${isLight ? '☀' : '☾'}</span> ${themeLabel().split(' ')[1]}`;
+        updateThemeToggle();
       });
     }
 

--- a/templates/champion.html
+++ b/templates/champion.html
@@ -3,9 +3,8 @@
 {% block content %}
 <section class="page-header">
   <div>
-    <p class="eyebrow">{{ champ_name }}</p>
-    <h1>Rank every skin by community vote.</h1>
-    <p class="lede">Click a splash to view it in detail. Sign in to cast a single vote per skin and watch rankings reorder instantly.</p>
+    <p class="eyebrow">Champion</p>
+    <h1>{{ champ_name }} skins</h1>
     {% if champion_lore %}
       <p class="muted" style="max-width: 720px;">{{ champion_lore }}</p>
     {% endif %}
@@ -51,7 +50,7 @@
           </div>
           <div class="vote">
             <button class="vote__button" data-voted="{{ 'true' if vote_data.voted else 'false' }}">
-              <span class="emoji-mono" aria-hidden="true">⬆</span> {{ 'Remove' if vote_data.voted else 'Vote' }}
+              {{ 'Remove' if vote_data.voted else 'Vote' }}
             </button>
             <div class="vote__count" id="vote-count-{{ skin.skin_num }}">{{ vote_data.count }}</div>
           </div>
@@ -123,7 +122,7 @@
           countEl.textContent = data.votes;
           const isVoted = data.status === 'added';
           btn.dataset.voted = isVoted ? 'true' : 'false';
-          btn.innerHTML = `<span class="emoji-mono" aria-hidden="true">⬆</span> ${isVoted ? 'Remove' : 'Vote'}`;
+          btn.innerHTML = isVoted ? 'Remove' : 'Vote';
           sortSkins();
         } else {
           const error = await response.json();


### PR DESCRIPTION
## Summary
- remove About and Contact links from the top navigation and simplify the theme toggle to an emoji-only control
- streamline champion pages by replacing the repeated tagline with a concise heading and removing the arrow icon from vote buttons
- tweak page header and vote button spacing to keep padding consistent across the layout

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b1a270bfc832bb1c01353d3050c73)